### PR TITLE
fix shim for ie8

### DIFF
--- a/lib/loaders/client/handlebars-shim.js
+++ b/lib/loaders/client/handlebars-shim.js
@@ -1,3 +1,3 @@
 var Handlebars = require('handlebars/runtime');
 // TODO: Remove this shim layer after updating to handlebars 3.
-module.exports = Handlebars.default || Handlebars;
+module.exports = Handlebars['default'] || Handlebars;


### PR DESCRIPTION
fixes #4

ie8 pukes on the `default` because it thinks its a reserved word.